### PR TITLE
Treat benign augustus rc>0 exits as no-hit, only save debug artifacts on signal death

### DIFF
--- a/buscolite/busco.py
+++ b/buscolite/busco.py
@@ -198,9 +198,18 @@ def predict_and_validate(
                 configpath=configpath,
             )
         except subprocess.CalledProcessError as e:
-            debug_dir = _save_augustus_debug(t_fasta.name, e, busco_name)
-            e.buscolite_debug_dir = debug_dir
-            raise
+            # POSIX: signal-terminated children have negative returncodes (e.g.
+            # -4 SIGILL, -11 SIGSEGV). Those are real crashes — preserve debug
+            # artifacts and re-raise so the caller can log and skip.
+            # A positive returncode (e.g. rc=1 "No feasible path found in HMM")
+            # is augustus exiting normally with "no gene found in this region"
+            # — treat it as a silent no-hit to avoid spamming the log and
+            # $TMPDIR with one entry per missed region.
+            if e.returncode is not None and e.returncode < 0:
+                debug_dir = _save_augustus_debug(t_fasta.name, e, busco_name)
+                e.buscolite_debug_dir = debug_dir
+                raise
+            return False
     finally:
         try:
             os.unlink(t_fasta.name)

--- a/tests/test_busco.py
+++ b/tests/test_busco.py
@@ -4,6 +4,7 @@ Tests for the busco module.
 
 import os
 import subprocess
+import tempfile
 from unittest.mock import patch
 
 import pytest  # noqa: F401 - Needed for pytest fixtures
@@ -145,6 +146,69 @@ def test_predict_and_validate_saves_debug_artifacts_on_failure(tmp_path):
         assert f.read().strip() == "-4"
     with open(os.path.join(debug_dir, "stderr.txt")) as f:
         assert "illegal instruction" in f.read()
+
+
+def test_predict_and_validate_sigsegv_saves_artifacts(tmp_path):
+    """Any negative returncode (e.g. -11 SIGSEGV) is treated as a signal
+    death: artifacts are persisted and the exception is re-raised."""
+    prfl = str(tmp_path / "busco42.prfl")
+    open(prfl, "w").close()
+
+    cmd = ["augustus", "--fake", "arg"]
+    err = subprocess.CalledProcessError(-11, cmd, output=None, stderr="segfault\n")
+
+    with patch("buscolite.busco.proteinprofile", side_effect=err):
+        with pytest.raises(subprocess.CalledProcessError) as excinfo:
+            predict_and_validate(
+                _minimal_fadict(),
+                "contig1",
+                prfl,
+                cutoffs={"busco42": {"score": 100.0}},
+                species="human",
+                start=0,
+                end=20,
+                strand="+",
+                configpath="/nope",
+                blast_score=1.0,
+            )
+
+    debug_dir = getattr(excinfo.value, "buscolite_debug_dir", None)
+    assert debug_dir is not None and os.path.isdir(debug_dir)
+    with open(os.path.join(debug_dir, "returncode.txt")) as f:
+        assert f.read().strip() == "-11"
+
+
+def test_predict_and_validate_benign_nonzero_exit_is_nohit(tmp_path):
+    """rc>0 CalledProcessError (augustus' normal "No feasible path found in
+    HMM" exit) returns False silently — no debug dir, no re-raise."""
+    prfl = str(tmp_path / "busco42.prfl")
+    open(prfl, "w").close()
+
+    debug_root = os.path.join(tempfile.gettempdir(), "buscolite_debug")
+    before = set(os.listdir(debug_root)) if os.path.isdir(debug_root) else set()
+
+    cmd = ["augustus", "--fake", "arg"]
+    err = subprocess.CalledProcessError(
+        1, cmd, output=None, stderr="augustus: ERROR\n\tNo feasible path found in HMM\n"
+    )
+
+    with patch("buscolite.busco.proteinprofile", side_effect=err):
+        result = predict_and_validate(
+            _minimal_fadict(),
+            "contig1",
+            prfl,
+            cutoffs={"busco42": {"score": 100.0}},
+            species="human",
+            start=0,
+            end=20,
+            strand="+",
+            configpath="/nope",
+            blast_score=1.0,
+        )
+
+    assert result is False
+    after = set(os.listdir(debug_root)) if os.path.isdir(debug_root) else set()
+    assert after == before, "benign rc>0 must not leave debug dirs behind"
 
 
 def test_predict_and_validate_cleans_up_on_success(tmp_path):


### PR DESCRIPTION
## Summary

Follow-up to #3. The resilience fix in that PR treated **every** non-zero augustus exit as a crash — saving debug artifacts, logging a warning, and skipping the job. In practice, augustus routinely exits with `rc=1` and `"No feasible path found in HMM"` when a sliced region simply doesn't contain a gene model matching the profile. On a multi-thousand-job genome run this produced:

- thousands of warning lines in the log (one per missed region), and
- thousands of debug directories accumulating under `$TMPDIR/buscolite_debug/`.

Those are not crashes — they're augustus saying "no gene here", which is a normal outcome for the majority of BUSCO×region pairs.

## Fix

Distinguish real crashes from benign non-zero exits using the sign of the returncode. POSIX signal-terminated children have **negative** returncodes (e.g. `-4` SIGILL, `-11` SIGSEGV); normal non-zero exits are positive.

In `buscolite/busco.py::predict_and_validate`:

- `returncode < 0` (signal death): save debug artifacts, attach `.buscolite_debug_dir`, re-raise. **Unchanged from #3.**
- `returncode > 0` (augustus "No feasible path" and similar): return `False` (no hit) silently. No debug dir, no log.

The tempfile cleanup in `finally` is unchanged, and `execute_timeout` / `process_busco_jobs` are not touched.

## Example log impact

Before:
```
augustus failed for BUSCO 1363701at4890 on contig_417:9811-13904 (reverse) rc=1 — skipping. debug_dir=/var/folders/.../buscolite_debug/1363701at4890_35223_...
```
(×thousands, with matching debug dirs.)

After: silent no-hit — treated the same as any other BUSCO that didn't match a region. Real augustus crashes (signal deaths) still produce one warning and one debug dir each.

## Tests

Two new tests in `tests/test_busco.py`:

- `test_predict_and_validate_sigsegv_saves_artifacts` — `rc=-11` (SIGSEGV-style) still saves artifacts and re-raises, confirming the crash path works for any negative rc, not just `-4`.
- `test_predict_and_validate_benign_nonzero_exit_is_nohit` — `rc=1` with the real augustus "No feasible path" stderr returns `False`, creates no debug directory, and does not raise.

The existing `test_predict_and_validate_saves_debug_artifacts_on_failure` (rc=-4) still passes unchanged.

## Verification

- `python3 -m pytest tests/test_busco.py -v` — **13/13 pass** (11 pre-existing + 2 new).
- `python3 -m pytest tests/ -q --ignore=tests/integration` — **75/75 pass**.
- `pre-commit run --files buscolite/busco.py tests/test_busco.py` — black, isort, flake8 all clean.

## Backward Compatibility

- Public API unchanged.
- Crash-path behavior (negative rc) is byte-identical to #3.
- The only behavior change is that `predict_and_validate` now returns `False` instead of raising `CalledProcessError` on positive non-zero rc. Callers that don't already treat a raised `CalledProcessError` as a hard error (which is everything in this codebase) are unaffected; the no-hit return value flows through `process_busco_jobs` just like any other miss.

---

Pull Request opened by [Augment Code](https://www.augmentcode.com/) with guidance from the PR author