### PR TITLE
Classify augustus self-test failures with actionable diagnostics

### DIFF
--- a/buscolite/augustus.py
+++ b/buscolite/augustus.py
@@ -1,4 +1,5 @@
 import os
+import signal
 import subprocess
 import sys
 
@@ -27,6 +28,19 @@ def augustus_version():
 
 
 def augustus_functional():
+    """
+    Run augustus with --proteinprofile on a small bundled example and check
+    whether the binary is usable on this host. Returns True if augustus
+    produced the expected gene prediction marker, False otherwise.
+
+    On failure, a diagnostic line is written to stderr distinguishing:
+      * augustus binary missing from PATH
+      * augustus killed by a signal (typically SIGILL — the binary contains
+        CPU instructions this host cannot run, e.g. a linux/amd64 bioconda
+        build under Apple Silicon / Rosetta 2, or pre-AVX hardware)
+      * augustus exited non-zero with its own "augustus: ERROR" message
+      * augustus exited cleanly but produced no recognizable output
+    """
     datadir = os.path.join(os.path.dirname(__file__), "data")
     cmd = [
         "augustus",
@@ -38,27 +52,54 @@ def augustus_functional():
         "--stopCodonExcludedFromCDS=False",
         os.path.join(datadir, "example.fa"),
     ]
-    functional = False
-    proc = subprocess.Popen(
-        cmd, stdout=subprocess.PIPE, stderr=subprocess.PIPE, universal_newlines=True
-    )
-    stdout, stderr = proc.communicate()
-    stderr = stderr.strip()
-    if isinstance(stdout, str):
+    try:
+        proc = subprocess.run(
+            cmd,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            universal_newlines=True,
+            timeout=120,
+        )
+    except FileNotFoundError:
+        sys.stderr.write("augustus binary not found on PATH\n")
+        return False
+    except subprocess.TimeoutExpired:
+        sys.stderr.write("augustus --proteinprofile self-test timed out after 120s\n")
+        return False
+
+    stdout = (proc.stdout or "").strip()
+    stderr = (proc.stderr or "").strip()
+    rc = proc.returncode
+
+    if rc is not None and rc < 0:
+        sig = -rc
         try:
-            stdout = stdout.decode("ascii", "ignore").encode("ascii")
-        except AttributeError:
-            pass
-    stdout = stdout.strip().split("\n")
+            sig_name = signal.Signals(sig).name
+        except (ValueError, AttributeError):
+            sig_name = ""
+        sys.stderr.write(
+            "augustus --proteinprofile self-test was killed by signal {} ({}). "
+            "This typically means the augustus binary contains CPU "
+            "instructions your host does not support — most commonly seen "
+            "when running a linux/amd64 docker image on Apple Silicon via "
+            "Rosetta 2, or on older x86_64 hardware lacking AVX/AVX2/BMI2. "
+            "Run on real x86_64 hardware or use a native install.\n".format(sig, sig_name)
+        )
+        return False
+
     if stderr.startswith("augustus: ERROR"):
         sys.stderr.write(stderr + "\n")
-        return functional
-    else:
-        for line in stdout:
-            line = line.strip()
-            if line.startswith("# start gene g1"):
-                functional = True
-    return functional
+        return False
+
+    for line in stdout.split("\n"):
+        if line.strip().startswith("# start gene g1"):
+            return True
+
+    sys.stderr.write(
+        "augustus --proteinprofile self-test exited rc={} but produced no "
+        "gene prediction. stderr was: {!r}\n".format(rc, stderr[:500])
+    )
+    return False
 
 
 def proteinprofile(

--- a/buscolite/busco.py
+++ b/buscolite/busco.py
@@ -375,7 +375,7 @@ def runbusco(
         if check_augustus:
             if not augustus_functional():
                 logger.error(
-                    "Augustus PPX (--proteinprofile) is non-functional. Usually caused by compilation errors."
+                    "Augustus PPX (--proteinprofile) self-test failed; see stderr above for details. Common causes: augustus missing or broken, augustus compiled without --enable-proteinprofile, or a CPU/binary mismatch (e.g. linux/amd64 bioconda build under Rosetta 2)."
                 )
                 raise SystemExit(1)
         if verbosity >= 1:


### PR DESCRIPTION
## Summary

`augustus_functional()` previously surfaced only augustus's own `"augustus: ERROR"` stderr lines, and otherwise returned `False` without explanation. When the augustus binary was killed by `SIGILL` — as happens with the bioconda `linux/amd64` build under Rosetta 2 on Apple Silicon, or on pre-AVX/BMI2 x86_64 hardware — no error was printed at all; the caller saw a bare `False` and downstream the run produced 0 BUSCO hits across thousands of models with no obvious cause.

This PR keeps the existing signature and return type but classifies the failure mode and writes an actionable diagnostic to stderr in each case.

## Changes

### `buscolite/augustus.py`

`augustus_functional()` now uses `subprocess.run` with a 120s timeout and classifies outcomes into four buckets, each with a dedicated stderr line:

| Outcome | Diagnostic |
|---|---|
| `FileNotFoundError` | `augustus binary not found on PATH` |
| `rc < 0` (killed by signal N) | `augustus … killed by signal {N} ({name}). This typically means the augustus binary contains CPU instructions your host does not support — most commonly seen when running a linux/amd64 docker image on Apple Silicon via Rosetta 2, or on older x86_64 hardware lacking AVX/AVX2/BMI2. Run on real x86_64 hardware or use a native install.` |
| `stderr.startswith("augustus: ERROR")` | preserved (augustus's own message) |
| clean exit, no `# start gene g1` marker | `augustus … exited rc={rc} but produced no gene prediction. stderr was: {…}` |

### `buscolite/busco.py`

`runbusco()`'s error message no longer blames "compilation errors" generically. It now points the user at the augustus stderr that `augustus_functional()` now produces and lists realistic root causes (missing binary, missing `--enable-proteinprofile`, CPU/binary mismatch).

## Behavioral compatibility

- `augustus_functional()` still returns `bool`.
- `runbusco()` still `SystemExit(1)`s on failure.
- No new dependencies.
- The only observable change is that failures now print a self-explanatory line to stderr before the existing error path runs.

## Related

Companion to the funannotate2 change that re-enables `check_augustus=True` in `train.py:buscolite()` and switches the Docker image to install augustus from Ubuntu apt rather than bioconda. With both PRs in place, a future binary mismatch fails loudly at the first augustus call instead of silently producing 0 hits.

---
Pull Request opened by [Augment Code](https://www.augmentcode.com/) with guidance from the PR author