### PR TITLE
Add support for ODB12 and ODB12.2 lineages

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -17,7 +17,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.8", "3.9", "3.10", "3.11", "3.12"]
+        python-version: ["3.8", "3.9", "3.10", "3.11", "3.12", "3.13"]
 
     steps:
     - uses: actions/checkout@v4

--- a/buscolite/busco.py
+++ b/buscolite/busco.py
@@ -58,7 +58,7 @@ def load_cutoffs(lineage):
     -------
     dict
         Dictionary containing the score and length cutoffs for each BUSCO model
-        Format: {busco_id: {"score": float, "sigma": float, "length": int}}
+        Format: {busco_id: {"score": float, "sigma": float, "length": int, "median": float, "sMAD": float}}
     """
     cutoffs = {}
     with open(os.path.join(lineage, "scores_cutoff"), "r") as infile:
@@ -73,17 +73,29 @@ def load_cutoffs(lineage):
     if os.path.isfile(length_cutoffs):
         with open(length_cutoffs, "r") as infile:
             for line in infile:
-                busco, _, sigma, length = line.rstrip().split("\t")
-                if float(sigma) == 0.0:
-                    sigma = 1
-                if busco not in cutoffs:
-                    cutoffs[busco] = {
-                        "sigma": float(sigma),
-                        "length": int(float(length)),
-                    }
-                else:
-                    cutoffs[busco]["sigma"] = float(sigma)
-                    cutoffs[busco]["length"] = int(float(length))
+                parts = line.rstrip().split("\t")
+                if len(parts) == 4:
+                    busco, _, sigma, length = parts
+                    if float(sigma) == 0.0:
+                        sigma = 1
+                    if busco not in cutoffs:
+                        cutoffs[busco] = {
+                            "sigma": float(sigma),
+                            "length": int(float(length)),
+                        }
+                    else:
+                        cutoffs[busco]["sigma"] = float(sigma)
+                        cutoffs[busco]["length"] = int(float(length))
+                elif len(parts) == 3:
+                    busco, median, smad = parts
+                    if busco not in cutoffs:
+                        cutoffs[busco] = {
+                            "median": float(median),
+                            "sMAD": float(smad),
+                        }
+                    else:
+                        cutoffs[busco]["median"] = float(median)
+                        cutoffs[busco]["sMAD"] = float(smad)
     return cutoffs
 
 
@@ -146,6 +158,58 @@ def _save_augustus_debug(fasta_path, err, busco_name):
     with open(os.path.join(debug_dir, "stderr.txt"), "w") as f:
         f.write(stderr_text)
     return debug_dir
+
+
+def is_match_complete(busco_name, hmm_len, qlen, cutoffs):
+    """
+    Determine if a match is complete based on HMM length and lineage cutoffs.
+
+    Parameters
+    ----------
+    busco_name : str
+        Name of the BUSCO model
+    hmm_len : int
+        Length of the aligned match on the HMM profile
+    qlen : int
+        Length of the HMM profile (number of match states)
+    cutoffs : dict
+        Dictionary of cutoffs
+
+    Returns
+    -------
+    bool
+        True if the match is complete, False otherwise
+    """
+    model_cutoffs = cutoffs.get(busco_name, {})
+
+    # ODB12.2: has median and sMAD keys
+    if "median" in model_cutoffs and "sMAD" in model_cutoffs:
+        median = model_cutoffs["median"]
+        smad = model_cutoffs["sMAD"]
+        # Match length must be greater than the smallest of:
+        # 1. 90% of median length
+        # 2. median - (2 x sMAD) (capped at 25% of the median length)
+        # 3. 80% of HMM profile length (qlen)
+        t1 = 0.9 * median
+        t2 = median - min(2.0 * smad, 0.25 * median)
+        t3 = 0.8 * qlen
+        min_len = min(t1, t2, t3)
+        max_len = 1.5 * median
+        return min_len <= hmm_len <= max_len
+
+    # ODB10: has length and sigma keys
+    elif "length" in model_cutoffs and "sigma" in model_cutoffs:
+        length = model_cutoffs["length"]
+        sigma = model_cutoffs["sigma"]
+        # Complete if zeta <= 2
+        # zeta = (length - hmm_len) / sigma
+        # So: hmm_len >= length - 2 * sigma
+        return hmm_len >= (length - 2.0 * sigma)
+
+    # ODB12: no lengths_cutoff file, so only score cutoff is present
+    else:
+        # Complete if hmm_len >= 80% of HMM profile length (qlen)
+        return hmm_len >= 0.8 * qlen
 
 
 def predict_and_validate(
@@ -233,6 +297,11 @@ def predict_and_validate(
             hmm_result = hmmer_search_single(hmmfile, protein.rstrip("*"))
             if len(hmm_result) > 0:
                 if hmm_result[0]["bitscore"] > cutoffs[busco_name]["score"]:
+                    hmm_len = hmm_result[0]["hmm_len"]
+                    qlen = hmm_result[0]["qlen"]
+                    if status == "complete":
+                        if not is_match_complete(busco_name, hmm_len, qlen, cutoffs):
+                            status = "fragmented"
                     final = {
                         "contig": v["contig"],
                         "strand": v["strand"],
@@ -757,6 +826,11 @@ def runbusco(
             "missing": len(missing),
         }
         for k, v in natsorted(b_results.items()):
+            # Classify complete vs fragmented first
+            for x in v:
+                is_comp = is_match_complete(k, x["hmm_len"], x["qlen"], CutOffs)
+                x["status"] = "complete" if is_comp else "fragmented"
+
             if len(v) > 1:  # duplicates
                 for i, x in enumerate(sorted(v, key=lambda y: y["bitscore"], reverse=True)):
                     x["status"] = "duplicated"
@@ -770,11 +844,9 @@ def runbusco(
             else:
                 x = v[0]
                 x["length"] = falengths[x["hit"]]
-                if "status" in x and x["status"] == "fragmented":
+                if x["status"] == "fragmented":
                     stats["fragmented"] += 1
-                    x["status"] = "fragmented"
                 else:
-                    x["status"] = "complete"
                     stats["single-copy"] += 1
                 b_final[k] = x
 

--- a/buscolite/search.py
+++ b/buscolite/search.py
@@ -565,6 +565,25 @@ def merge_overlapping_hits(queryList, fluff=10000):
     return result
 
 
+def sum_hmm_len(hmm_coords):
+    """
+    Sum the lengths of non-overlapping HMM regions.
+    """
+    hmm_regions_sorted = sorted(hmm_coords, key=lambda x: x[0])
+    hmm_regions_used = []
+    for region in hmm_regions_sorted:
+        for used in hmm_regions_used:
+            if (
+                used[0] <= region[0] <= used[1]
+            ):  # if any new coord contained in previous region, expand if necessary
+                if region[1] > used[1]:
+                    used[1] = region[1]
+                break
+        else:
+            hmm_regions_used.append(list(region))
+    return sum([region[1] - region[0] + 1 for region in hmm_regions_used])
+
+
 def hmmer_search_single(hmmfile, seq):
     """
     Search a single protein sequence against an HMM profile using pyhmmer.
@@ -584,6 +603,8 @@ def hmmer_search_single(hmmfile, seq):
         - bitscore: Bit score of the hit
         - evalue: E-value of the hit
         - domains: List of domain hits with coordinates and scores
+        - hmm_len: Length of the aligned match on the HMM profile
+        - qlen: Length of the HMM profile
     """
     hmm = next(pyhmmer.plan7.HMMFile(hmmfile))
     prot = pyhmmer.easel.TextSequence(sequence=seq)
@@ -603,12 +624,16 @@ def hmmer_search_single(hmmfile, seq):
                         "score": h.score,
                     }
                 )
+            hmm_coords = [(d["hmm_from"], d["hmm_to"]) for d in domains]
+            hmm_len = sum_hmm_len(hmm_coords)
             results.append(
                 {
                     "name": cog,
                     "bitscore": hit.score,
                     "evalue": hit.evalue,
                     "domains": domains,
+                    "hmm_len": hmm_len,
+                    "qlen": hmm.M,
                 }
             )
     return results
@@ -634,6 +659,8 @@ def hmmer_search(hmmfile, sequences):
         - bitscore: Bit score of the hit
         - evalue: E-value of the hit
         - domains: List of domain hits with coordinates and scores
+        - hmm_len: Length of the aligned match on the HMM profile
+        - qlen: Length of the HMM profile
     """
     hmm = next(pyhmmer.plan7.HMMFile(hmmfile))
     results = []
@@ -651,6 +678,8 @@ def hmmer_search(hmmfile, sequences):
                         "score": h.score,
                     }
                 )
+            hmm_coords = [(d["hmm_from"], d["hmm_to"]) for d in domains]
+            hmm_len = sum_hmm_len(hmm_coords)
             results.append(
                 {
                     "name": cog,
@@ -658,6 +687,8 @@ def hmmer_search(hmmfile, sequences):
                     "bitscore": hit.score,
                     "evalue": hit.evalue,
                     "domains": domains,
+                    "hmm_len": hmm_len,
+                    "qlen": hmm.M,
                 }
             )
     return results

--- a/tests/test_busco.py
+++ b/tests/test_busco.py
@@ -11,6 +11,7 @@ import pytest  # noqa: F401 - Needed for pytest fixtures
 
 from buscolite.busco import (
     check_lineage,
+    is_match_complete,
     load_config,
     load_cutoffs,
     predict_and_validate,
@@ -45,6 +46,50 @@ def test_load_cutoffs(mock_busco_lineage):
     assert cutoffs["busco2"]["score"] == 200.0
     assert cutoffs["busco2"]["sigma"] == 1.0  # Should be 1 because sigma was 0.0
     assert cutoffs["busco2"]["length"] == 400
+
+
+def test_load_cutoffs_odb12_2(temp_dir):
+    """Test loading cutoffs from ODB12.2 lineage containing median and sMAD."""
+    lineage_dir = os.path.join(temp_dir, "mock_lineage_odb12_2")
+    os.makedirs(lineage_dir, exist_ok=True)
+    with open(os.path.join(lineage_dir, "scores_cutoff"), "w") as f:
+        f.write("busco1\t100.0\n")
+    with open(os.path.join(lineage_dir, "lengths_cutoff"), "w") as f:
+        f.write("busco1\t500.0\t50.0\n")
+
+    cutoffs = load_cutoffs(lineage_dir)
+    assert cutoffs["busco1"]["score"] == 100.0
+    assert cutoffs["busco1"]["median"] == 500.0
+    assert cutoffs["busco1"]["sMAD"] == 50.0
+    assert "length" not in cutoffs["busco1"]
+
+
+def test_is_match_complete():
+    """Test is_match_complete function for ODB10, ODB12, and ODB12.2 cutoffs."""
+    # 1. ODB10: length=300, sigma=10.0 -> threshold is 300 - 2*10 = 280
+    cutoffs_odb10 = {"busco1": {"length": 300, "sigma": 10.0}}
+    assert is_match_complete("busco1", 290, 300, cutoffs_odb10) is True
+    assert is_match_complete("busco1", 280, 300, cutoffs_odb10) is True
+    assert is_match_complete("busco1", 270, 300, cutoffs_odb10) is False
+
+    # 2. ODB12: no length/median keys -> threshold is 80% of profile length (qlen)
+    cutoffs_odb12 = {"busco1": {"score": 100.0}}
+    assert is_match_complete("busco1", 85, 100, cutoffs_odb12) is True
+    assert is_match_complete("busco1", 80, 100, cutoffs_odb12) is True
+    assert is_match_complete("busco1", 75, 100, cutoffs_odb12) is False
+
+    # 3. ODB12.2: median=500.0, sMAD=50.0
+    # t1 = 0.9 * median = 450.0
+    # t2 = median - min(2 * sMAD, 0.25 * median) = 500 - min(100, 125) = 400.0
+    # t3 = 0.8 * profile_length (let profile_length = 500 -> 400.0)
+    # min_len = min(450.0, 400.0, 400.0) = 400.0
+    # max_len = 1.5 * median = 750.0
+    cutoffs_odb12_2 = {"busco1": {"median": 500.0, "sMAD": 50.0}}
+    assert is_match_complete("busco1", 450, 500, cutoffs_odb12_2) is True
+    assert is_match_complete("busco1", 400, 500, cutoffs_odb12_2) is True
+    assert is_match_complete("busco1", 399, 500, cutoffs_odb12_2) is False
+    assert is_match_complete("busco1", 750, 500, cutoffs_odb12_2) is True
+    assert is_match_complete("busco1", 751, 500, cutoffs_odb12_2) is False
 
 
 def test_check_lineage_valid(mock_busco_lineage):


### PR DESCRIPTION
This PR adds support for OrthoDB v12 and v12.2 lineage datasets. It updates cutoff loading to support both 3-column (median/sMAD) and 4-column configurations, and integrates completeness rules dynamically.